### PR TITLE
Minor: Guard against same-name variables across substores

### DIFF
--- a/src/store/CreateUseFunStore.ts
+++ b/src/store/CreateUseFunStore.ts
@@ -31,9 +31,10 @@ export const createUseFunStore = () => {
     const errorStore = configureErrorStore(get, set)
 
     // Build the full store:
-    // Declaratively list out all substore variables instead of spreading
+    // 1. Declaratively list out all substore variables instead of spreading
     // to guard against same-name variables being declared across different stores
     // which would cause overriding and make things hard to maintain / debug.
+    // 2. Typecast to `useFunStoreInterface` to ensure no necessary variables are missed.
     const fullStore: useFunStoreInterface = {
       // Fun Account Store
       FunWallet: funAccountStore.FunWallet,

--- a/src/store/CreateUseFunStore.ts
+++ b/src/store/CreateUseFunStore.ts
@@ -21,83 +21,79 @@ export interface useFunStoreInterface
 }
 
 export const createUseFunStore = () => {
-  return createWithEqualityFn(
-    (set: any, get: any): useFunStoreInterface => {
-      // Substores
-      const funAccountStore = configureFunAccountStore(get, set);
-      const authStore = configureAuthStore(get, set);
-      const chainStore = configureChainStore(get, set);
-      const configStore = configureConfigurationStore(get, set);
-      const txnStore = configureTransactionStore(get, set);
-      const errorStore = configureErrorStore(get, set);
+  return createWithEqualityFn((set: any, get: any): useFunStoreInterface => {
+    // Substores
+    const funAccountStore = configureFunAccountStore(get, set)
+    const authStore = configureAuthStore(get, set)
+    const chainStore = configureChainStore(get, set)
+    const configStore = configureConfigurationStore(get, set)
+    const txnStore = configureTransactionStore(get, set)
+    const errorStore = configureErrorStore(get, set)
 
-      // Build the full store:
-      // Declaratively list out all substore variables instead of spreading 
-      // to guard against same-name variables being declared across different stores 
-      // which would cause overriding and make things hard to maintain / debug.
-      const fullStore: useFunStoreInterface = {
-        
-        // Fun Account Store
-        FunWallet: funAccountStore.FunWallet,
-        setFunWallet: funAccountStore.setFunWallet,
-        account: funAccountStore.account,
-        setAccount: funAccountStore.setAccount,
-        setLogin: funAccountStore.setLogin,
-        ensName: funAccountStore.ensName,
-        setEnsName: funAccountStore.setEnsName,
-        
-        // Auth Store
-        activeAuthClients: authStore.activeAuthClients,
-        setActiveAuthClients: authStore.setActiveAuthClients,
-        activeClientSubscriber: authStore.activeClientSubscriber,
-        setActiveClientSubscriber: authStore.setActiveClientSubscriber,
-        FunGroupAccounts: authStore.FunGroupAccounts,
-        setFunGroupAccounts: authStore.setFunGroupAccounts,
-        FunAccounts: authStore.FunAccounts,
-        setFunAccounts: authStore.setFunAccounts,
-        activeUser: authStore.activeUser,
-        setActiveUser: authStore.setActiveUser,
-        allUsers: authStore.allUsers,
-        setAllUsers: authStore.setAllUsers,
-        setNewAccountUsers: authStore.setNewAccountUsers,
+    // Build the full store:
+    // Declaratively list out all substore variables instead of spreading
+    // to guard against same-name variables being declared across different stores
+    // which would cause overriding and make things hard to maintain / debug.
+    const fullStore: useFunStoreInterface = {
+      // Fun Account Store
+      FunWallet: funAccountStore.FunWallet,
+      setFunWallet: funAccountStore.setFunWallet,
+      account: funAccountStore.account,
+      setAccount: funAccountStore.setAccount,
+      setLogin: funAccountStore.setLogin,
+      ensName: funAccountStore.ensName,
+      setEnsName: funAccountStore.setEnsName,
 
-        // Chain Store
-        chain: chainStore.chain,
-        chainId: chainStore.chainId,
-        supportedChains: chainStore.supportedChains,
-        setSupportedChains: chainStore.setSupportedChains,
-        switchChain: chainStore.switchChain,
+      // Auth Store
+      activeAuthClients: authStore.activeAuthClients,
+      setActiveAuthClients: authStore.setActiveAuthClients,
+      activeClientSubscriber: authStore.activeClientSubscriber,
+      setActiveClientSubscriber: authStore.setActiveClientSubscriber,
+      FunGroupAccounts: authStore.FunGroupAccounts,
+      setFunGroupAccounts: authStore.setFunGroupAccounts,
+      FunAccounts: authStore.FunAccounts,
+      setFunAccounts: authStore.setFunAccounts,
+      activeUser: authStore.activeUser,
+      setActiveUser: authStore.setActiveUser,
+      allUsers: authStore.allUsers,
+      setAllUsers: authStore.setAllUsers,
+      setNewAccountUsers: authStore.setNewAccountUsers,
 
-        // Configuration Store
-        config: configStore.config,
-        updateConfig: configStore.updateConfig,
-        setConfig: configStore.setConfig,
+      // Chain Store
+      chain: chainStore.chain,
+      chainId: chainStore.chainId,
+      supportedChains: chainStore.supportedChains,
+      setSupportedChains: chainStore.setSupportedChains,
+      switchChain: chainStore.switchChain,
 
-        // Txn Store
-        transactions: txnStore.transactions,
-        lastTransaction: txnStore.lastTransaction,
-        addTransaction: txnStore.addTransaction,
-        operations: txnStore.operations,
-        addOperation: txnStore.addOperation,
+      // Configuration Store
+      config: configStore.config,
+      updateConfig: configStore.updateConfig,
+      setConfig: configStore.setConfig,
 
+      // Txn Store
+      transactions: txnStore.transactions,
+      lastTransaction: txnStore.lastTransaction,
+      addTransaction: txnStore.addTransaction,
+      operations: txnStore.operations,
+      addOperation: txnStore.addOperation,
 
-        // Error Store
-        error: errorStore.error,
-        errors: errorStore.errors,
-        txError: errorStore.txError,
-        setFunError: errorStore.setFunError,
-        setTempError: errorStore.setTempError,
-        setTxError: errorStore.setTxError,
-        resetFunError: errorStore.resetFunError,
-        resetFunErrors: errorStore.resetFunErrors,
-        resetTxError: errorStore.resetTxError,
+      // Error Store
+      error: errorStore.error,
+      errors: errorStore.errors,
+      txError: errorStore.txError,
+      setFunError: errorStore.setFunError,
+      setTempError: errorStore.setTempError,
+      setTxError: errorStore.setTxError,
+      resetFunError: errorStore.resetFunError,
+      resetFunErrors: errorStore.resetFunErrors,
+      resetTxError: errorStore.resetTxError,
 
-        // Misc
-        setAssets: (assets) => set({ assets }),
-        assets: null,
-      };
-
-      return fullStore as useFunStoreInterface;
+      // Misc
+      setAssets: (assets) => set({ assets }),
+      assets: null,
     }
-  )
+
+    return fullStore as useFunStoreInterface
+  })
 }

--- a/src/store/CreateUseFunStore.ts
+++ b/src/store/CreateUseFunStore.ts
@@ -22,15 +22,82 @@ export interface useFunStoreInterface
 
 export const createUseFunStore = () => {
   return createWithEqualityFn(
-    (set: any, get: any): useFunStoreInterface => ({
-      ...configureFunAccountStore(get, set),
-      ...configureAuthStore(get, set),
-      ...configureChainStore(get, set),
-      ...configureConfigurationStore(get, set),
-      ...configureTransactionStore(get, set),
-      ...configureErrorStore(get, set),
-      setAssets: (assets) => set({ assets }),
-      assets: null,
-    })
+    (set: any, get: any): useFunStoreInterface => {
+      // Substores
+      const funAccountStore = configureFunAccountStore(get, set);
+      const authStore = configureAuthStore(get, set);
+      const chainStore = configureChainStore(get, set);
+      const configStore = configureConfigurationStore(get, set);
+      const txnStore = configureTransactionStore(get, set);
+      const errorStore = configureErrorStore(get, set);
+
+      // Build the full store:
+      // Declaratively list out all substore variables instead of spreading 
+      // to guard against same-name variables being declared across different stores 
+      // which would cause overriding and make things hard to maintain / debug.
+      const fullStore: useFunStoreInterface = {
+        
+        // Fun Account Store
+        FunWallet: funAccountStore.FunWallet,
+        setFunWallet: funAccountStore.setFunWallet,
+        account: funAccountStore.account,
+        setAccount: funAccountStore.setAccount,
+        setLogin: funAccountStore.setLogin,
+        ensName: funAccountStore.ensName,
+        setEnsName: funAccountStore.setEnsName,
+        
+        // Auth Store
+        activeAuthClients: authStore.activeAuthClients,
+        setActiveAuthClients: authStore.setActiveAuthClients,
+        activeClientSubscriber: authStore.activeClientSubscriber,
+        setActiveClientSubscriber: authStore.setActiveClientSubscriber,
+        FunGroupAccounts: authStore.FunGroupAccounts,
+        setFunGroupAccounts: authStore.setFunGroupAccounts,
+        FunAccounts: authStore.FunAccounts,
+        setFunAccounts: authStore.setFunAccounts,
+        activeUser: authStore.activeUser,
+        setActiveUser: authStore.setActiveUser,
+        allUsers: authStore.allUsers,
+        setAllUsers: authStore.setAllUsers,
+        setNewAccountUsers: authStore.setNewAccountUsers,
+
+        // Chain Store
+        chain: chainStore.chain,
+        chainId: chainStore.chainId,
+        supportedChains: chainStore.supportedChains,
+        setSupportedChains: chainStore.setSupportedChains,
+        switchChain: chainStore.switchChain,
+
+        // Configuration Store
+        config: configStore.config,
+        updateConfig: configStore.updateConfig,
+        setConfig: configStore.setConfig,
+
+        // Txn Store
+        transactions: txnStore.transactions,
+        lastTransaction: txnStore.lastTransaction,
+        addTransaction: txnStore.addTransaction,
+        operations: txnStore.operations,
+        addOperation: txnStore.addOperation,
+
+
+        // Error Store
+        error: errorStore.error,
+        errors: errorStore.errors,
+        txError: errorStore.txError,
+        setFunError: errorStore.setFunError,
+        setTempError: errorStore.setTempError,
+        setTxError: errorStore.setTxError,
+        resetFunError: errorStore.resetFunError,
+        resetFunErrors: errorStore.resetFunErrors,
+        resetTxError: errorStore.resetTxError,
+
+        // Misc
+        setAssets: (assets) => set({ assets }),
+        assets: null,
+      };
+
+      return fullStore as useFunStoreInterface;
+    }
   )
 }


### PR DESCRIPTION
## Problem

Currently, in `createUseFunStore()`, substores are being populated into the main store via spread syntax `({ ... })` like:

```ts
export const createUseFunStore = () => {
  return createWithEqualityFn(
    (set: any, get: any): useFunStoreInterface => ({
      ...configureFunAccountStore(get, set),
      ...configureAuthStore(get, set),
      ...configureChainStore(get, set),
      ...configureConfigurationStore(get, set),
      ...configureTransactionStore(get, set),
      ...configureErrorStore(get, set),
      setAssets: (assets) => set({ assets }),
      assets: null,
    })
  )
}
```

While this works fine, it runs the risk of **same-name variables colliding / overriding** each other in the future as more stores get added. 

This sets sdk devs up for failure by making the code hard to maintain and/or debug.

## Changes / Fix

There are simple changes to address the issue:

1. **[New]** Declaratively list out all substore variables (into a new var `fullStore`) instead of spreading
2. **[New]** Add typecasting `fullStore: useFunStoreInterface` so that no new variables are missed or removed variables are lingering
3. **[Misc]** Add comments

## Verification

**1. A dev declaring a new substore variable that already exists in another substore will be notified via an error:**

https://github.com/fun-xyz/funkit-react/assets/95644202/23fe5c07-79f5-480b-94a7-e063cba1ebf8

**2. A dev accidentally removing a substore variable will be notified via an error:**

https://github.com/fun-xyz/funkit-react/assets/95644202/71660e33-ca6f-41fa-8704-c32b9756e60f


